### PR TITLE
One step closer to systemctl independence

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -60,9 +60,6 @@ def get_stage_config(stage):
 
 def get_service():
     ''' Return the configured service name.'''
-    if not _config['service']:
-        halt('No service has been configured yet.')
-
     return _config['service']
 
 

--- a/boss/init.py
+++ b/boss/init.py
@@ -4,11 +4,22 @@ import sys
 from fabric.api import env, task
 from .config import load as load_config, get as get_config, get_stage_config
 from .api.shell import get_stage
+from .util import warn_deprecated
 
 
 def init(module_name):
     ''' Initialize the boss configuration. '''
     config = load_config()
+
+    # This service config option makes it too tightly coupled with
+    # systemd services, so we'll need to make deployment process
+    # independent of systemctl.
+    if config['service'] != None:
+        warn_deprecated(
+            'The `service` configuration option is deprecated' +
+            ' and will be removed in the future releases.'
+        )
+
     stage = get_stage()
     module = sys.modules[module_name]
     define_stage_tasks(module, config)

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -36,7 +36,6 @@ def deploy(branch=None):
     # Get the latest code from the repository
     sync(branch)
 
-    systemctl.stop(service)
     # Installing dependencies
     npm.install()
 

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -26,7 +26,6 @@ def check():
 def deploy(branch=None):
     ''' The deploy task. '''
     branch = branch or fallback_branch(stage)
-    service = get_service()
     notif.send(notif.DEPLOYMENT_STARTED, {
         'user': shell.get_user(),
         'branch': branch,
@@ -42,10 +41,13 @@ def deploy(branch=None):
     # Building the app
     build(stage)
 
-    # Enable and Restart the service
-    systemctl.enable(service)
-    systemctl.restart(service)
-    systemctl.status(service)
+    service = get_service()
+
+    if service:
+        # Enable and Restart the service if service is provided
+        systemctl.enable(service)
+        systemctl.restart(service)
+        systemctl.status(service)
 
     notif.send(notif.DEPLOYMENT_FINISHED, {
         'branch': branch,

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -5,7 +5,7 @@ Default tasks Module.
 from fabric.api import run, hide, task
 from fabric.context_managers import shell_env
 from .api import git, notif, shell, npm, systemctl
-from .util import info
+from .util import info, warn_deprecated
 from .config import fallback_branch, get_service
 
 stage = shell.get_stage()
@@ -77,19 +77,35 @@ def build(stage_name=None):
 
 @task
 def stop():
-    ''' Stop the service. '''
+    ''' Stop the systemctl service. '''
+    # Deprecate everything that is tightly coupled to systemd
+    # as they are subject to change in the major future release.
+    warn_deprecated(
+        'The `stop` task is deprecated and will be either removed' +
+        ' or subject to change in the major future release.'
+    )
     systemctl.stop(get_service())
 
 
 @task
 def restart():
     ''' Restart the service. '''
+    # Deprecate everything that is tightly coupled to systemd
+    # as they are subject to change in the major future release.
+    warn_deprecated(
+        'The `restart` task is deprecated and will be either removed' +
+        ' or subject to change in the major future release.'
+    )
     systemctl.restart(get_service())
 
 
 @task
 def status():
     ''' Get the status of the service. '''
+    warn_deprecated(
+        'The `status` task is deprecated and will be either removed' +
+        ' or subject to change in the major future release.'
+    )
     systemctl.status(get_service())
 
 

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -4,9 +4,9 @@ Default tasks Module.
 
 from fabric.api import run, hide, task
 from fabric.context_managers import shell_env
-from .api import git, notif, shell, npm, systemctl
 from .util import info, warn_deprecated
-from .config import fallback_branch, get_service
+from .api import git, notif, shell, npm, systemctl
+from .config import fallback_branch, get_service, get_stage_config, get as get_config
 
 stage = shell.get_stage()
 
@@ -112,7 +112,16 @@ def status():
 @task
 def logs():
     ''' Tail the logs. '''
-    run('sudo journalctl -f -u %s' % get_service())
+    # Tail the logs from journalctl if
+    # systemctl service is configured
+    if get_service():
+        warn_deprecated(
+            'Using journalctl to tail the logs from ' +
+            'configured service is deprecated. ' +
+            'You\'ll need to provide the config explicitly for logging.'
+        )
+        run('sudo journalctl -f -u %s' % get_service())
+
 
 __all__ = ['deploy', 'check', 'sync', 'build',
            'stop', 'restart', 'status', 'logs']

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -121,6 +121,16 @@ def logs():
             'You\'ll need to provide the config explicitly for logging.'
         )
         run('sudo journalctl -f -u %s' % get_service())
+        return
+
+    # Get the logging config
+    stage_specific_logging = get_stage_config(stage).get('logging')
+    logging_config = stage_specific_logging or get_config().get('logging')
+
+    if logging_config and logging_config.get('files'):
+        # Tail the logs from log files
+        log_paths = ' '.join(logging_config.get('files'))
+        run('tail -f ' + log_paths)
 
 
 __all__ = ['deploy', 'check', 'sync', 'build',

--- a/boss/util.py
+++ b/boss/util.py
@@ -4,7 +4,7 @@ Module for utility functions
 
 import collections
 from copy import deepcopy
-from fabric.colors import red, green
+from fabric.colors import red, green, yellow
 
 
 def halt(msg):
@@ -14,7 +14,17 @@ def halt(msg):
 
 def info(msg):
     ''' Print a message (Information) '''
-    print '\n' + green(msg)
+    print('\n' + green(msg))
+
+
+def warn(msg):
+    ''' Print a warning message. '''
+    print('\n' + yellow(msg))
+
+
+def warn_deprecated(msg):
+    ''' Print a deprecated warning message. '''
+    warn('Deprecated: {}'.format(msg))
 
 
 def merge(dict1, dict2):


### PR DESCRIPTION
So far our tasks have been tightly coupled with systemd, so we'll need to make deployment process independent of `systemctl`. This will be done in the future releases. 

For now using `systemctl` dependent tasks like `status`, `restart`, `stop` and the `service` option would print a deprecation warning. 

Moreover, the `logs` task has been improved to support tailing log files in addition to using `journalctl` on the configured `service` which now is deprecated. This resolves https://github.com/kabirbaidhya/boss-cli/issues/1.

