### PR TITLE
Allow setting private key (pem) file via boss.yml

### DIFF
--- a/boss/constants.py
+++ b/boss/constants.py
@@ -4,6 +4,7 @@ DEFAULT_CONFIG_FILE = 'boss.yml'
 DEFAULT_CONFIG = {
     'user': 'boss',
     'port': 22,
+    'key_filename': '~/.ssh/id_rsa',
     'app_dir': '~/',
     'branch': 'dev',
     'repository_url': '',

--- a/boss/init.py
+++ b/boss/init.py
@@ -42,4 +42,5 @@ def configure_env():
     env.user = stage_config.get('user') or config['user']
     env.port = stage_config.get('port') or config['port']
     env.cwd = stage_config.get('app_dir') or config['app_dir']
+    env.key_filename = stage_config.get('key_filename') or config['key_filename']
     env.hosts = [stage_config['host']]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from boss import __version__
 
 
 this_dir = abspath(dirname(__file__))
-with open(join(this_dir, 'README.rst'), encoding='utf-8') as file:
+with open(join(this_dir, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
 
 


### PR DESCRIPTION
* This will allow providing a SSH private key / pem file via the `key_filename` param in the `boss.yml` which is just like setting `env.key_filename = '/path/to/pemfile'`
* Default value of `env.key_filename` will now be `~/.ssh/id_rsa`