### PR TITLE
Support custom scripts similar to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Comming soon ;)
 ## Configuration
 
 ### Custom Scripts
-Custom scripts are one liner scripts/commands that could be defined directly in the config file without having to write any line of python in the `fabfile.py`. They're similar to the the [npm scripts](https://docs.npmjs.com/misc/scripts), if you're familiar with it.
+Custom scripts are scripts/commands that could be defined directly in the config file without having to write any line of python in the `fabfile.py`. They're similar to the [npm scripts](https://docs.npmjs.com/misc/scripts), if you're familiar with them.
 
 You can define the custom scripts under the `scripts` field in the `boss.yml`.
 
@@ -30,7 +30,7 @@ scripts:
   logs: pm2 logs
 ```
 
-Boss comes out of the box with a task `run` which you can use to run these scripts on the remote server something like this:
+Boss comes out of the box with a task `run` which you can use to run these scripts on the remote server like this:
 ```bash
 $ fab dev run:hello
 $ fab dev run:build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 boss-cli
 =========
 
-Yet another pythonic deployment tool built on top of fabric.
+Yet another pythonic deployment tool built on top of [fabric](http://www.fabfile.org/).
 
 Deploy like a boss.
 
@@ -14,10 +14,31 @@ $ pip install boss-cli
 ## Usage
 Comming soon ;)
 
+## Configuration
+
+### Custom Scripts
+Custom scripts are one liner scripts/commands that could be defined directly in the config file without having to write any line of python in the `fabfile.py`. They're similar to the the [npm scripts](https://docs.npmjs.com/misc/scripts), if you're familiar with it.
+
+You can define the custom scripts under the `scripts` field in the `boss.yml`.
+
+**For instance:**
+```yaml
+# boss.yml
+scripts:
+  hello: 'echo "Hello World!"'
+  build: npm run build
+  logs: pm2 logs
+```
+
+Boss comes out of the box with a task `run` which you can use to run these scripts on the remote server something like this:
+```bash
+$ fab dev run:hello
+$ fab dev run:build
+$ fab dev run:logs
+```
+
 ## Change Log
 Check the [CHANGELOG](CHANGELOG.md) for full release history.
 
 ## License
 Licensed under [The MIT License](LICENSE).
-
-

--- a/boss.yml.example
+++ b/boss.yml.example
@@ -48,6 +48,10 @@ stages:
                 - /path/to/production/log/file.log
                 - /path/to/production/another/log/file.log
 
+# Define custom scripts here.
+scripts:
+    hello: 'echo "Hello World"'
+
 notifications:
     slack:
         enabled: true

--- a/boss/api/runner.py
+++ b/boss/api/runner.py
@@ -11,12 +11,19 @@ def run(command, remote=True):
         _local(command)
 
 
+def is_script_defined(script):
+    ''' Check if the script is defined in the config. '''
+    custom_scripts = _get_config()['scripts']
+
+    return custom_scripts.has_key(script)
+
+
 def run_script(script, remote=True):
     ''' Run a script. '''
     custom_scripts = _get_config()['scripts']
 
     # If the script is not defined raise error.
-    if not custom_scripts.has_key(script):
+    if not is_script_defined(script):
         raise RuntimeError('Missing script "{}"'.format(script))
 
     # Get the command defined in the script.

--- a/boss/api/runner.py
+++ b/boss/api/runner.py
@@ -1,0 +1,26 @@
+
+from fabric.api import run as _run, local as _local
+from ..config import get as _get_config
+
+
+def run(command, remote=True):
+    ''' Run a command using fabric. '''
+    if remote:
+        _run(command)
+    else:
+        _local(command)
+
+
+def run_script(script, remote=True):
+    ''' Run a script. '''
+    custom_scripts = _get_config()['scripts']
+
+    # If the script is not defined raise error.
+    if not custom_scripts.has_key(script):
+        raise RuntimeError('Missing script "{}"'.format(script))
+
+    # Get the command defined in the script.
+    script_cmd = custom_scripts[script]
+
+    # Run a custom script defined in the config.
+    run(script_cmd, remote)

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -13,6 +13,7 @@ DEFAULT_CONFIG = {
     'branch_url': '{repository_url}/branch/{branch}',
     'service': None,
     'stages': {},
+    'scripts': {},
     'notifications': {
         'slack': {
             'enabled': False,

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -2,7 +2,7 @@
 Default tasks Module.
 '''
 
-from fabric.api import run, hide, task
+from fabric.api import run as _run, hide, task
 from fabric.context_managers import shell_env
 from .util import info, warn_deprecated
 from .api import git, notif, shell, npm, systemctl
@@ -17,7 +17,7 @@ def check():
     with hide('running'):
         # Show the current branch
         remote_branch = git.remote_branch()
-        run('echo "Branch: %s"' % remote_branch)
+        _run('echo "Branch: %s"' % remote_branch)
         # Show the last commit
         git.show_last_commit()
 
@@ -120,7 +120,7 @@ def logs():
             'configured service is deprecated. ' +
             'You\'ll need to provide the config explicitly for logging.'
         )
-        run('sudo journalctl -f -u %s' % get_service())
+        _run('sudo journalctl -f -u %s' % get_service())
         return
 
     # Get the logging config
@@ -130,8 +130,15 @@ def logs():
     if logging_config and logging_config.get('files'):
         # Tail the logs from log files
         log_paths = ' '.join(logging_config.get('files'))
-        run('tail -f ' + log_paths)
+        _run('tail -f ' + log_paths)
+
+
+@task
+def run(script):
+    ''' Run a custom script. '''
+    print('Running {}'.format(script))
+    # TODO: Run a custom script defined in the config.
 
 
 __all__ = ['deploy', 'check', 'sync', 'build',
-           'stop', 'restart', 'status', 'logs']
+           'stop', 'restart', 'status', 'logs', 'run']

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -4,8 +4,8 @@ Default tasks Module.
 
 from fabric.api import run as _run, hide, task
 from fabric.context_managers import shell_env
-from .util import info, warn_deprecated
-from .api import git, notif, shell, npm, systemctl
+from .util import info, warn_deprecated, halt
+from .api import git, notif, shell, npm, systemctl, runner
 from .config import fallback_branch, get_service, get_stage_config, get as get_config
 
 stage = shell.get_stage()
@@ -136,18 +136,11 @@ def logs():
 @task
 def run(script):
     ''' Run a custom script. '''
-    custom_scripts = get_config()['scripts']
-
-    # If the script is not defined just print the message.
-    if not custom_scripts.has_key(script):
-        print('Script "{}" is not defined'.format(script))
-        return
-
-    # Get the command defined in the script.
-    script_cmd = custom_scripts[script]
-
     # Run a custom script defined in the config.
-    _run(script_cmd)
+    try:
+        runner.run_script(script)
+    except RuntimeError, e:
+        halt(str(e))
 
 
 __all__ = ['deploy', 'check', 'sync', 'build',

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -136,8 +136,18 @@ def logs():
 @task
 def run(script):
     ''' Run a custom script. '''
-    print('Running {}'.format(script))
-    # TODO: Run a custom script defined in the config.
+    custom_scripts = get_config()['scripts']
+
+    # If the script is not defined just print the message.
+    if not custom_scripts.has_key(script):
+        print('Script "{}" is not defined'.format(script))
+        return
+
+    # Get the command defined in the script.
+    script_cmd = custom_scripts[script]
+
+    # Run a custom script defined in the config.
+    _run(script_cmd)
 
 
 __all__ = ['deploy', 'check', 'sync', 'build',


### PR DESCRIPTION
This PR aims to add support for Custom Scripts as defined in https://github.com/kabirbaidhya/boss-cli/issues/16.

### What are custom scripts?
Custom scripts are one liner scripts/commands that could be defined directly in the config file without having to write any line of python in the `fabfile.py`. They're similar to the the [npm scripts](https://docs.npmjs.com/misc/scripts), if you're familiar with it.

You can define the custom scripts under the `scripts` field in the `boss.yml`.

**For instance:**
```yaml
# boss.yml
scripts:
  hello: 'echo "Hello World!"'
  build: npm run build
  logs: pm2 logs
```

New task `run` has been added which you can use to run these scripts on the remote server something like this:
```bash
$ fab dev run:hello
$ fab dev run:build
$ fab dev run:logs
```
Closes https://github.com/kabirbaidhya/boss-cli/issues/16