### PR TITLE
Interpolate environment variables in boss.yml

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -2,7 +2,9 @@
 
 import os
 from copy import deepcopy
+
 import yaml
+import dotenv
 from .util import halt, merge
 from .constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE
 _config = deepcopy(DEFAULT_CONFIG)
@@ -20,6 +22,12 @@ def load(filename=DEFAULT_CONFIG_FILE):
     ''' Load the configuration and return it. '''
     try:
         with open(filename) as file_contents:
+            # Load environment variables from .env file if it exists.
+            dotenv_path = os.path.join(os.path.dirname(filename), '.env')
+
+            if os.path.exists(dotenv_path):
+                dotenv.load_dotenv(dotenv_path)
+
             # Expand the environment variables used in the yaml config.
             loaded_config = os.path.expandvars(file_contents.read())
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -1,10 +1,10 @@
 ''' The configuration specific Module. '''
 
+import os
 from copy import deepcopy
 import yaml
 from .util import halt, merge
 from .constants import DEFAULT_CONFIG, DEFAULT_CONFIG_FILE
-
 _config = deepcopy(DEFAULT_CONFIG)
 
 
@@ -20,7 +20,11 @@ def load(filename=DEFAULT_CONFIG_FILE):
     ''' Load the configuration and return it. '''
     try:
         with open(filename) as file_contents:
-            loaded_config = yaml.load(file_contents)
+            # Expand the environment variables used in the yaml config.
+            loaded_config = os.path.expandvars(file_contents.read())
+
+            # Parse the yaml configuration.
+            loaded_config = yaml.load(loaded_config)
             merged_config = merge(DEFAULT_CONFIG, loaded_config)
             _config.update(merged_config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ paramiko==2.1.2
 pyparsing==2.2.0
 PyYAML==3.12
 requests==2.17.3
+python-dotenv==0.6.5

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,12 @@ setup(
     ],
     keywords='cli',
     packages=find_packages(exclude=['docs', 'tests*']),
-    install_requires=['fabric', 'pyyaml', 'requests'],
+    install_requires=[
+        'fabric==1.13.2',
+        'pyyaml==3.12',
+        'requests==2.17.3',
+        'python-dotenv==0.6.5'
+    ],
     extras_require={
         'test': ['coverage', 'pytest', 'pytest-cov'],
     },


### PR DESCRIPTION
* Load environment variables from `.env` file using `python-dotenv` if the file is present in the same directory as `boss.yml`.
* POSIX Expansion of environment variables if used in `boss.yml`
* **Secret keys and sensitive information are now recommended to be injected via these environment variables in the boss.yml**

Resolves https://github.com/kabirbaidhya/boss-cli/issues/21