### PR TITLE
Make use of custom scripts in deployment and other tasks

### DIFF
--- a/boss/api/runner.py
+++ b/boss/api/runner.py
@@ -18,6 +18,15 @@ def is_script_defined(script):
     return custom_scripts.has_key(script)
 
 
+def run_script_safely(script, remote=True):
+    '''
+    Run a script only if it is defined in the config.
+    Otherwise, it's skipped without throwing an error.
+    '''
+    if is_script_defined(script):
+        run_script(script, remote)
+
+
 def run_script(script, remote=True):
     ''' Run a script. '''
     custom_scripts = _get_config()['scripts']

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -35,11 +35,10 @@ DEFAULT_CONFIG = {
 }
 
 # Predefined custom scripts/hooks
-SCRIPT_INSTALL = 'install'
-SCRIPT_RESTART = 'restart'
 SCRIPT_STOP = 'stop'
-SCRIPT_START = 'start'
-SCRIPT_RELOAD = 'reload'
 SCRIPT_LOGS = 'logs'
+SCRIPT_START = 'start'
 SCRIPT_BUILD = 'build'
+SCRIPT_RELOAD = 'reload'
+SCRIPT_INSTALL = 'install'
 SCRIPT_STATUS_CHECK = 'status_check'

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -33,3 +33,13 @@ DEFAULT_CONFIG = {
         }
     }
 }
+
+# Predefined custom scripts/hooks
+SCRIPT_INSTALL = 'install'
+SCRIPT_RESTART = 'restart'
+SCRIPT_STOP = 'stop'
+SCRIPT_START = 'start'
+SCRIPT_RELOAD = 'reload'
+SCRIPT_LOGS = 'logs'
+SCRIPT_BUILD = 'build'
+SCRIPT_STATUS_CHECK = 'status_check'

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -103,7 +103,18 @@ def sync(branch=None):
 def build(stage_name=None):
     ''' Build the application. '''
     with shell_env(STAGE=(stage_name or stage)):
-        npm.run('build')
+        # Trigger the build script.
+        runner.run_script_safely(constants.SCRIPT_BUILD)
+
+        # Fallback to old npm run build way, if the build script is not defined.
+        # TODO: Remove this (BC Break).
+        if not runner.is_script_defined(constants.SCRIPT_BUILD):
+            warn_deprecated(
+                'Define `{}` script explicitly if you need to '.format(constants.SCRIPT_BUILD) +
+                'build. ' +
+                'In future releases `npm run build` won\'t be triggered on deployment.'
+            )
+            npm.run('build')
 
 
 @task


### PR DESCRIPTION
* Make use of custom scripts in deployment and other tasks.
* Add predefined scripts for special purposes:
  - `stop` - Stop the service
  - `logs` - Tail the logs
  - `start` - Start the service
  - `build` - Build the application
  - `reload` - Reload the application
  - `install` - Install dependencies
  - `status_check` - Check status of the services
* Encourage the use of predefined custom scripts as a means of hooks for installing dependencies, building, starting/stopping/reloading services, checking service status etc.
* Print deprecation/warning messages for `npm` dependent commands like `npm install`, `npm run build` and `systemctl` dependent commands like `journalctl`, `status`, `restart`, `stop` etc.
