### PR TITLE
Support deployment preset and change the default deployment to remote source deployment preset

### DIFF
--- a/boss/api/deployer.py
+++ b/boss/api/deployer.py
@@ -1,0 +1,23 @@
+from boss import constants
+from boss.util import warn_deprecated, halt
+
+
+def import_preset(config):
+    ''' Import the configured deployment preset module and return it. '''
+    preset = config['deployment']['preset']
+
+    if not preset:
+        warn_deprecated(
+            'Set deployment preset explicitly, if you need deployment tasks. ' +
+            'In the future releases, deployment tasks won\'t be available unless ' +
+            'you have set the preset.'
+        )
+        # TODO: In future release, don't import deployment tasks
+        # unless the preset is set. (BC Break)
+        from boss.api.deployment import remote_source as module
+    elif preset == constants.PRESET_REMOTE_SOURCE:
+        from boss.api.deployment import remote_source as module
+    else:
+        halt('Unsupported boss preset "{}".'.format(preset))
+
+    return module

--- a/boss/api/deployment/remote_source.py
+++ b/boss/api/deployment/remote_source.py
@@ -1,4 +1,11 @@
-''' Deployer for Remote Source deployment Preset. '''
+'''
+Remote Source deployment Preset.
+
+This is a generic deployment, where the project source code and the git repository
+exists at the remote end. The deploy task would fetch the latest changes of the
+provided branch on the remote respository, then it's built and service is reloaded.
+'''
+
 
 from fabric.api import task, hide
 from fabric.colors import cyan

--- a/boss/api/deployment/remote_source.py
+++ b/boss/api/deployment/remote_source.py
@@ -1,0 +1,168 @@
+''' Deployer for Remote Source deployment Preset. '''
+
+from fabric.api import task, hide
+from fabric.colors import cyan
+from fabric.context_managers import shell_env
+
+import boss.constants as constants
+from boss.config import fallback_branch, get_service
+from boss.util import warn_deprecated, remote_info, remote_print
+from boss.api import git, notif, shell, npm, systemctl, runner
+
+
+@task
+def deploy(branch=None):
+    ''' Deploy to remote source. '''
+    stage = shell.get_stage()
+    branch = branch or fallback_branch(stage)
+    notif.send(notif.DEPLOYMENT_STARTED, {
+        'user': shell.get_user(),
+        'branch': branch,
+        'stage': stage
+    })
+
+    # Get the latest code from the repository
+    sync(branch)
+    install_dependencies()
+
+    # Building the app
+    build(stage)
+    reload_service()
+
+    notif.send(notif.DEPLOYMENT_FINISHED, {
+        'branch': branch,
+        'stage': stage
+    })
+
+    remote_info('Deployment Completed')
+
+
+def reload_service():
+    ''' Reload the service after deployment. '''
+    service = get_service()
+
+    if service:
+        # TODO: Remove this in future release (BC Break).
+        # Enable and Restart the service if service is provided
+        warn_deprecated(
+            'Reloading service using systemctl is deprecated and ' +
+            'will be removed in major future release. ' +
+            'Define `{}` script in your config instead.'.format(
+                constants.SCRIPT_RELOAD)
+        )
+        systemctl.enable(service)
+        systemctl.restart(service)
+        systemctl.status(service)
+    else:
+        # Trigger reload script if it's defined.
+        runner.run_script_safely(constants.SCRIPT_RELOAD)
+        runner.run_script_safely(constants.SCRIPT_STATUS_CHECK)
+
+
+def install_dependencies():
+    ''' Install dependencies. '''
+    # Trigger install script.
+    runner.run_script_safely(constants.SCRIPT_INSTALL)
+
+    # If install script is not defined,
+    # Fallback to old `npm install` for backwards compatilibity.
+    # TODO: Remove this in the next release (BC break).
+    if not runner.is_script_defined(constants.SCRIPT_INSTALL):
+        warn_deprecated(
+            'Define `{}` script explicitly if you need to '.format(constants.SCRIPT_INSTALL) +
+            'install dependencies on deployment. ' +
+            'In future releases `npm install` won\'t be triggered on deployment.'
+        )
+        npm.install()
+
+
+@task
+def sync(branch=None):
+    ''' Sync the changes on the branch with the remote (origin). '''
+    remote_info('Fetching the latest changes.')
+    git.fetch()
+    branch = branch or git.remote_branch()
+    remote_info('Checking out to branch {}.'.format(cyan(branch)))
+    git.checkout(branch, True)
+    remote_info('Synchronizing with the latest changes.')
+    git.sync(branch)
+
+
+@task
+def build(stage_name=None):
+    ''' Build the application. '''
+    stage = shell.get_stage()
+
+    with shell_env(STAGE=(stage_name or stage)):
+        # Trigger the build script.
+        runner.run_script_safely(constants.SCRIPT_BUILD)
+
+        # Fallback to old npm run build way, if the build script is not defined.
+        # TODO: Remove this (BC Break).
+        if not runner.is_script_defined(constants.SCRIPT_BUILD):
+            warn_deprecated(
+                'Define `{}` script explicitly if you need to '.format(constants.SCRIPT_BUILD) +
+                'build. ' +
+                'In future releases `npm run build` won\'t be triggered on deployment.'
+            )
+            npm.run('build')
+
+
+@task
+def stop():
+    ''' Stop the systemctl service. '''
+    runner.run_script_safely(constants.SCRIPT_STOP)
+
+    # Fallback to old systemctl stop, if the stop script is not defined.
+    # TODO: Remove this (BC Break).
+    if not runner.is_script_defined(constants.SCRIPT_STOP):
+        # Deprecate everything that is tightly coupled to systemd
+        # as they are subject to change in the major future release.
+        warn_deprecated(
+            'The `stop` using systemctl service task is deprecated. ' +
+            'Define `{}` script instead.'.format(constants.SCRIPT_STOP)
+        )
+        systemctl.stop(get_service())
+
+
+@task
+def restart():
+    ''' Restart the service. '''
+    runner.run_script_safely(constants.SCRIPT_RELOAD)
+
+    # Fallback to old systemctl way, if the script is not defined.
+    # TODO: Remove this (BC Break).
+    if not runner.is_script_defined(constants.SCRIPT_RELOAD):
+        # Deprecate everything that is tightly coupled to systemd
+        # as they are subject to change in the major future release.
+        warn_deprecated(
+            'The `restart` using systemctl service task is deprecated. ' +
+            'Define `{}` script instead.'.format(constants.SCRIPT_RELOAD)
+        )
+        systemctl.restart(get_service())
+
+
+@task
+def status():
+    ''' Get the status of the service. '''
+    runner.run_script_safely(constants.SCRIPT_STATUS_CHECK)
+
+    # Fallback to old systemctl way, if the script is not defined.
+    # TODO: Remove this (BC Break).
+    if not runner.is_script_defined(constants.SCRIPT_STATUS_CHECK):
+        warn_deprecated(
+            'The `status` using systemctl service task is deprecated. ' +
+            'Define `{}` script instead.'.format(constants.SCRIPT_STATUS_CHECK)
+        )
+        systemctl.status(get_service())
+
+
+@task
+def check():
+    ''' Check the current remote branch and the last commit. '''
+    with hide('running'):
+        # Show the current branch
+        remote_branch = git.remote_branch()
+        remote_print('Branch: {}'.format(remote_branch))
+        # Show the last commit
+        git.show_last_commit()

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -21,7 +21,7 @@ DEFAULT_CONFIG = {
     'stages': {},
     'scripts': {},
     'deployment': {
-        'preset': PRESET_REMOTE_SOURCE
+        'preset': None
     },
     'notifications': {
         'slack': {

--- a/boss/constants.py
+++ b/boss/constants.py
@@ -1,5 +1,11 @@
 ''' Application wide common constants module. '''
 
+# Predefined deployment presets
+PRESET_FRONTEND = 'frontend'
+PRESET_BACKEND_NODE = 'backend-node'
+PRESET_REMOTE_SOURCE = 'remote-source'
+
+# Default boss configuration
 DEFAULT_CONFIG_FILE = 'boss.yml'
 DEFAULT_CONFIG = {
     'user': 'boss',
@@ -14,6 +20,9 @@ DEFAULT_CONFIG = {
     'service': None,
     'stages': {},
     'scripts': {},
+    'deployment': {
+        'preset': PRESET_REMOTE_SOURCE
+    },
     'notifications': {
         'slack': {
             'enabled': False,

--- a/boss/init.py
+++ b/boss/init.py
@@ -2,9 +2,12 @@
 
 import sys
 from fabric.api import env, task
+from fabric.tasks import _is_task
+
+from . import constants
+from .util import warn_deprecated, halt
 from .config import load as load_config, get as get_config, get_stage_config
 from .api.shell import get_stage
-from .util import warn_deprecated
 
 
 def init(module_name):
@@ -23,15 +26,52 @@ def init(module_name):
     stage = get_stage()
     module = sys.modules[module_name]
     define_stage_tasks(module, config)
+    define_preset_tasks(module, config)
 
     return (config, stage)
+
+
+def import_configured_preset(config):
+    ''' Import the configured deployment preset module and return it. '''
+    preset = config['deployment']['preset']
+
+    if not preset:
+        warn_deprecated(
+            'Set deployment preset explicitly, if you need deployment tasks. ' +
+            'In the future releases, deployment tasks won\'t be available unless ' +
+            'you have set the preset.'
+        )
+        # TODO: In future release, don't import deployment tasks
+        # unless the preset is set. (BC Break)
+        from boss.api.deployment import remote_source as module
+    elif preset == constants.PRESET_REMOTE_SOURCE:
+        from boss.api.deployment import remote_source as module
+    else:
+        halt('Unsupported boss preset "{}".'.format(preset))
+
+    return module
+
+
+def define_preset_tasks(module, config):
+    ''' Define tasks for the configured deployment preset. '''
+    deployment = import_configured_preset(config)
+    # Now that we have deployment preset set, import all the tasks.
+    for (task_name, func) in deployment.__dict__.iteritems():
+        if not _is_task(func):
+            continue
+
+        # Set a new task named as the stage name in the main fabfile module.
+        setattr(module, task_name, func)
 
 
 def define_stage_tasks(module, config):
     ''' Define tasks for the stages dynamically. '''
     for (stage_name, _) in config['stages'].iteritems():
         task_func = task(name=stage_name)(configure_env)
-        task_func.__doc__ = 'Configures the {} server environment.'.format(stage_name)
+        task_func.__doc__ = 'Configures the {} server environment.'.format(
+            stage_name)
+
+        # Set a new task named as the stage name in the main fabfile module.
         setattr(module, stage_name, task_func)
 
 

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -47,7 +47,7 @@ def run(script):
     # Run a custom script defined in the config.
     try:
         runner.run_script(script)
-    except RuntimeError, e:
+    except RuntimeError as e:
         halt(str(e))
 
 __all__ = ['run', 'logs']

--- a/boss/tasks.py
+++ b/boss/tasks.py
@@ -1,171 +1,12 @@
 '''
-Default tasks Module.
+Boss default tasks module.
 '''
 
-from fabric.colors import cyan
-from fabric.api import run as _run, hide, task
-from fabric.context_managers import shell_env
+from fabric.api import run as _run, task
 import boss.constants as constants
-from .util import warn_deprecated, halt, remote_info, remote_print
-from .api import git, notif, shell, npm, systemctl, runner
-from .config import fallback_branch, get_service, get_stage_config, get as get_config
-
-stage = shell.get_stage()
-
-
-@task
-def check():
-    ''' Check the current remote branch and the last commit. '''
-    with hide('running'):
-        # Show the current branch
-        remote_branch = git.remote_branch()
-        remote_print('Branch: {}'.format(remote_branch))
-        # Show the last commit
-        git.show_last_commit()
-
-
-@task
-def deploy(branch=None):
-    ''' The deploy task. '''
-    branch = branch or fallback_branch(stage)
-    notif.send(notif.DEPLOYMENT_STARTED, {
-        'user': shell.get_user(),
-        'branch': branch,
-        'stage': stage
-    })
-
-    # Get the latest code from the repository
-    sync(branch)
-    install_dependencies()
-
-    # Building the app
-    build(stage)
-    reload_service()
-
-    notif.send(notif.DEPLOYMENT_FINISHED, {
-        'branch': branch,
-        'stage': stage
-    })
-
-    remote_info('Deployment Completed')
-
-
-def reload_service():
-    ''' Reload the service after deployment. '''
-    service = get_service()
-
-    if service:
-        # TODO: Remove this in future release (BC Break).
-        # Enable and Restart the service if service is provided
-        warn_deprecated(
-            'Reloading service using systemctl is deprecated and ' +
-            'will be removed in major future release. ' +
-            'Define `{}` script in your config instead.'.format(
-                constants.SCRIPT_RELOAD)
-        )
-        systemctl.enable(service)
-        systemctl.restart(service)
-        systemctl.status(service)
-    else:
-        # Trigger reload script if it's defined.
-        runner.run_script_safely(constants.SCRIPT_RELOAD)
-        runner.run_script_safely(constants.SCRIPT_STATUS_CHECK)
-
-
-def install_dependencies():
-    ''' Install dependencies. '''
-    # Trigger install script.
-    runner.run_script_safely(constants.SCRIPT_INSTALL)
-
-    # If install script is not defined,
-    # Fallback to old `npm install` for backwards compatilibity.
-    # TODO: Remove this in the next release (BC break).
-    if not runner.is_script_defined(constants.SCRIPT_INSTALL):
-        warn_deprecated(
-            'Define `{}` script explicitly if you need to '.format(constants.SCRIPT_INSTALL) +
-            'install dependencies on deployment. ' +
-            'In future releases `npm install` won\'t be triggered on deployment.'
-        )
-        npm.install()
-
-
-@task
-def sync(branch=None):
-    ''' Sync the changes on the branch with the remote (origin). '''
-    remote_info('Fetching the latest changes.')
-    git.fetch()
-    branch = branch or git.remote_branch()
-    remote_info('Checking out to branch {}.'.format(cyan(branch)))
-    git.checkout(branch, True)
-    remote_info('Synchronizing with the latest changes.')
-    git.sync(branch)
-
-
-@task
-def build(stage_name=None):
-    ''' Build the application. '''
-    with shell_env(STAGE=(stage_name or stage)):
-        # Trigger the build script.
-        runner.run_script_safely(constants.SCRIPT_BUILD)
-
-        # Fallback to old npm run build way, if the build script is not defined.
-        # TODO: Remove this (BC Break).
-        if not runner.is_script_defined(constants.SCRIPT_BUILD):
-            warn_deprecated(
-                'Define `{}` script explicitly if you need to '.format(constants.SCRIPT_BUILD) +
-                'build. ' +
-                'In future releases `npm run build` won\'t be triggered on deployment.'
-            )
-            npm.run('build')
-
-
-@task
-def stop():
-    ''' Stop the systemctl service. '''
-    runner.run_script_safely(constants.SCRIPT_STOP)
-
-    # Fallback to old systemctl stop, if the stop script is not defined.
-    # TODO: Remove this (BC Break).
-    if not runner.is_script_defined(constants.SCRIPT_STOP):
-        # Deprecate everything that is tightly coupled to systemd
-        # as they are subject to change in the major future release.
-        warn_deprecated(
-            'The `stop` using systemctl service task is deprecated. ' +
-            'Define `{}` script instead.'.format(constants.SCRIPT_STOP)
-        )
-        systemctl.stop(get_service())
-
-
-@task
-def restart():
-    ''' Restart the service. '''
-    runner.run_script_safely(constants.SCRIPT_RELOAD)
-
-    # Fallback to old systemctl way, if the script is not defined.
-    # TODO: Remove this (BC Break).
-    if not runner.is_script_defined(constants.SCRIPT_RELOAD):
-        # Deprecate everything that is tightly coupled to systemd
-        # as they are subject to change in the major future release.
-        warn_deprecated(
-            'The `restart` using systemctl service task is deprecated. ' +
-            'Define `{}` script instead.'.format(constants.SCRIPT_RELOAD)
-        )
-        systemctl.restart(get_service())
-
-
-@task
-def status():
-    ''' Get the status of the service. '''
-    runner.run_script_safely(constants.SCRIPT_STATUS_CHECK)
-
-    # Fallback to old systemctl way, if the script is not defined.
-    # TODO: Remove this (BC Break).
-    if not runner.is_script_defined(constants.SCRIPT_STATUS_CHECK):
-        warn_deprecated(
-            'The `status` using systemctl service task is deprecated. ' +
-            'Define `{}` script instead.'.format(constants.SCRIPT_STATUS_CHECK)
-        )
-        systemctl.status(get_service())
+from .util import warn_deprecated, halt
+from .api import shell, runner
+from .config import get_service, get_stage_config, get as get_config
 
 
 @task
@@ -184,6 +25,8 @@ def logs():
         return
 
     # Get the logging config
+
+    stage = shell.get_stage()
     stage_specific_logging = get_stage_config(stage).get('logging')
     logging_config = stage_specific_logging or get_config().get('logging')
 
@@ -207,6 +50,4 @@ def run(script):
     except RuntimeError, e:
         halt(str(e))
 
-
-__all__ = ['deploy', 'check', 'sync', 'build',
-           'stop', 'restart', 'status', 'logs', 'run']
+__all__ = ['run', 'logs']


### PR DESCRIPTION
* Add support for deployment presets
* For now only one preset is supported i.e 'remote-source'. The deployment tasks previously available are now moved to this preset and are now available only if `preset` is set to `remote-source`.
* It's also recommended to set a preset explicitly in the config if boss is used for deployment. In future (BC breaking) major releases, no deployment tasks would be available unless the preset is set.

Resolves #13 