### PR TITLE
Support stage-specific deployment configuration

### DIFF
--- a/boss/api/deployment/buildman.py
+++ b/boss/api/deployment/buildman.py
@@ -12,7 +12,7 @@ from fabric.colors import green, cyan
 from fabric.api import cd, hide
 
 from boss import BASE_PATH, __version__ as BOSS_VERSION, constants
-from boss.config import get as get_config
+from boss.config import get as get_config, get_stage_config
 from boss.util import remote_info, remote_print, merge, localize_utc_timestamp
 from boss.api import fs, shell
 
@@ -32,7 +32,8 @@ TS_FORMAT_LOCAL = '%Y-%m-%d %I:%M:%S %p'
 
 def get_deploy_dir():
     ''' Get the deployment base directory path. '''
-    config = get_config()
+    config = get_stage_config(shell.get_stage())
+
     return config['deployment']['base_dir'].rstrip('/')
 
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -53,7 +53,7 @@ def get_base_config():
         'port': _config.get('port'),
         'branch': _config.get('branch'),
         'app_dir': _config.get('app_dir'),
-        'repository_url': _config.get('app_dir')
+        'repository_url': _config.get('repository_url')
     }
 
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -53,7 +53,8 @@ def get_base_config():
         'port': _config.get('port'),
         'branch': _config.get('branch'),
         'app_dir': _config.get('app_dir'),
-        'repository_url': _config.get('repository_url')
+        'repository_url': _config.get('repository_url'),
+        'deployment': _config.get('deployment')
     }
 
 


### PR DESCRIPTION
Support overriding the `deployment` configuration for each stage allowing more stage-specific configuration.

For instance, now `boss.yml` supports this:
```yml
deployment:
  preset: frontend
  build_dir: build/
  base_dir: /source/app/deployment
  keep_builds: 5

stages:
  prod:
    host: my-app.com
    deployment:
      base_dir: /source/prod/deployment
      keep_builds: 10

  dev:
    host: my-app.com
    deployment:
      base_dir: /source/dev/deployment
```