### PR TITLE
Ability to resolve stage-specific .env file based on the deployment/task stage

### DIFF
--- a/boss/config.py
+++ b/boss/config.py
@@ -18,15 +18,25 @@ def get():
     return deepcopy(_config)
 
 
-def load(filename=DEFAULT_CONFIG_FILE):
+def resolve_dotenv_file(path, stage=None):
+    '''
+    Resolve dotenv file and load environment vars if it exists.
+    If stage parameter is provided, then stage specific .env file is resolved,
+    for instance .env.production if stage=production etc.
+    If stage is None, just .env file is resolved.
+    '''
+    filename = '.env' + ('' if not stage else '.{}'.format(stage))
+    dotenv_path = os.path.join(path, filename)
+
+    if os.path.exists(dotenv_path):
+        dotenv.load_dotenv(dotenv_path)
+
+
+def load(filename=DEFAULT_CONFIG_FILE, stage=None):
     ''' Load the configuration and return it. '''
     try:
         with open(filename) as file_contents:
-            # Load environment variables from .env file if it exists.
-            dotenv_path = os.path.join(os.path.dirname(filename), '.env')
-
-            if os.path.exists(dotenv_path):
-                dotenv.load_dotenv(dotenv_path)
+            resolve_dotenv_file(os.path.dirname(filename), stage)
 
             # Expand the environment variables used in the yaml config.
             loaded_config = os.path.expandvars(file_contents.read())

--- a/boss/config.py
+++ b/boss/config.py
@@ -51,8 +51,9 @@ def load(filename=DEFAULT_CONFIG_FILE, stage=None):
             _config.update(merged_config)
 
             # Add base config to each of the stage config
-            for (stage, stage_config) in _config['stages'].items():
-                _config['stages'][stage].update(get_stage_config(stage))
+            for (stage_name, _) in _config['stages'].items():
+                _config['stages'][stage_name].update(
+                    get_stage_config(stage_name))
 
             return get()
 

--- a/boss/config.py
+++ b/boss/config.py
@@ -27,9 +27,13 @@ def resolve_dotenv_file(path, stage=None):
     '''
     filename = '.env' + ('' if not stage else '.{}'.format(stage))
     dotenv_path = os.path.join(path, filename)
+    fallback_path = os.path.join(path, '.env')
 
     if os.path.exists(dotenv_path):
         dotenv.load_dotenv(dotenv_path)
+
+    elif os.path.exists(fallback_path):
+        dotenv.load_dotenv(fallback_path)
 
 
 def load(filename=DEFAULT_CONFIG_FILE, stage=None):

--- a/boss/init.py
+++ b/boss/init.py
@@ -12,9 +12,9 @@ from .api.deployment import deployer
 
 def init(module_name):
     ''' Initialize the boss configuration. '''
-    config = load_config()
-
     stage = get_stage()
+    config = load_config(stage=stage)
+
     module = sys.modules[module_name]
     define_stage_tasks(module, config)
     define_preset_tasks(module, config)


### PR DESCRIPTION
**Stage-specific environment files**
Instead of loading the same old `.env` file every time, it will now load stage-specific `.env` files in the format `.env.{stage}`.

For instance: 
If you now run.
```
$ fab production deploy
```
It will first try to resolve `.env.production` file, if it doesn't exist it will fallback to looking for `.env` file. If it's not found either, it will skip loading env file and proceed with the deployment.
