### PR TITLE
Support caching of builds on deployments

### DIFF
--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -66,7 +66,11 @@ DEFAULT_CONFIG = {
 # Preset specific defaults
 PSD = {}
 PSD[presets.REMOTE_SOURCE] = {}
-PSD[presets.WEB] = {}
+PSD[presets.WEB] = {
+    'deployment': {
+        'cache_builds': False
+    }
+}
 PSD[presets.NODE] = {
     'deployment': {
         'include_files': [

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -69,7 +69,7 @@ PSD = {}
 PSD[presets.REMOTE_SOURCE] = {}
 PSD[presets.WEB] = {
     'deployment': {
-        'cache_builds': False
+        'stage_independent_builds': False
     }
 }
 PSD[presets.NODE] = {

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -33,7 +33,8 @@ DEFAULT_CONFIG = {
         'base_dir': '~/deployment',
         'cache_builds': True,
         'keep_builds': 5,
-        'include_files': []
+        'include_files': [],
+        'stage_independent_builds': True
     },
     'notifications': {
         'slack': {

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -67,11 +67,7 @@ DEFAULT_CONFIG = {
 # Preset specific defaults
 PSD = {}
 PSD[presets.REMOTE_SOURCE] = {}
-PSD[presets.WEB] = {
-    'deployment': {
-        'stage_independent_builds': False
-    }
-}
+PSD[presets.WEB] = {}
 PSD[presets.NODE] = {
     'deployment': {
         'include_files': [

--- a/boss/core/constants/config.py
+++ b/boss/core/constants/config.py
@@ -31,6 +31,7 @@ DEFAULT_CONFIG = {
         'preset': presets.REMOTE_SOURCE,
         'build_dir': None,
         'base_dir': '~/deployment',
+        'cache_builds': True,
         'keep_builds': 5,
         'include_files': []
     },

--- a/boss/core/initializer.py
+++ b/boss/core/initializer.py
@@ -2,10 +2,11 @@
 Module to deal with the initialization of environment
 for boss i.e generating config files and fabfile.
 '''
-from os import mkdir
+import os
+from os import mkdir, path
 
 from boss import BASE_PATH
-from boss.core import fs
+from boss.core import fs, hashing
 from boss.constants import (
     FABFILE_PATH,
     BOSS_HOME_PATH,
@@ -88,3 +89,18 @@ def setup_boss_home():
 
     if not fs.exists(BOSS_CACHE_PATH):
         mkdir(BOSS_CACHE_PATH)
+
+    setup_project_cache_path()
+
+
+def setup_project_cache_path(project_path=None):
+    '''
+    Get the cache path for the project, boss was initialized for.
+    '''
+    project_path = project_path or os.getcwd()
+    project_cache_path = path.join(BOSS_CACHE_PATH, hashing.md5(project_path))
+
+    if not fs.exists(project_cache_path):
+        mkdir(project_cache_path)
+
+    return project_cache_path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,18 +223,3 @@ def test_merge_config_that_by_default_cache_builds_is_true():
     merged_config = merge_config(raw_config)
 
     assert merged_config['deployment']['cache_builds'] is True
-
-
-def test_merge_config_that_by_default_cache_builds_is_false_if_preset_web():
-    '''
-    Ensure build caching is turned off for web preset, i.e
-    cache_build=False by default if not set.
-    '''
-    raw_config = {
-        'deployment': {
-            'preset': presets.WEB
-        }
-    }
-    merged_config = merge_config(raw_config)
-
-    assert merged_config['deployment']['cache_builds'] is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from mock import patch
 from boss.core.util.string import strip_ansi
+from boss.core.constants import presets
 from boss.core.constants.config import DEFAULT_CONFIG
 from boss.config import (
     load,
@@ -211,3 +212,29 @@ def test_resolve_dotenv_file_loads_env_file_if_stage_specific_file_doesnt_exist(
         msg = strip_ansi(info_m.call_args[0][0])
 
         assert msg == 'Resolving env file: .env'
+
+
+def test_merge_config_that_by_default_cache_builds_is_true():
+    '''
+    Ensure build caching is turned on, i.e
+    cache_build=True by default if not set.
+    '''
+    raw_config = {}
+    merged_config = merge_config(raw_config)
+
+    assert merged_config['deployment']['cache_builds'] is True
+
+
+def test_merge_config_that_by_default_cache_builds_is_false_if_preset_web():
+    '''
+    Ensure build caching is turned off for web preset, i.e
+    cache_build=False by default if not set.
+    '''
+    raw_config = {
+        'deployment': {
+            'preset': presets.WEB
+        }
+    }
+    merged_config = merge_config(raw_config)
+
+    assert merged_config['deployment']['cache_builds'] is False


### PR DESCRIPTION
* Add `cache_builds` config option. Defaults to `true`.
* Ability to cache builds on deployment.
* Introduce `stage_independent_builds` to determine whether or not the deployment build is stage dependent or not.